### PR TITLE
Convert function to esm as chalk >= 5 is esm-only

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,13 +3,17 @@
 /**
  * Cli Should Cancel.
  */
-const chalk = require("chalk");
+import chalk from "chalk";
+import process from "process";
+
 const yellow = chalk.bold.yellow;
 
 // Exit gracefully if user trying to cancel.
-module.exports = async action => {
+const cliShouldCancel = async (action) => {
 	if (action === undefined) {
 		console.log(yellow(`❯ Cancelled!\n`));
 		process.exit(0);
 	}
 };
+
+export default cliShouldCancel;


### PR DESCRIPTION
Chalk from version 5 is esm only, and the current version of it will make this function fail.